### PR TITLE
fix: update skills.sh README link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ It is intended for developers building applications for **Apple Vision Pro**, le
 
 ## Skills
 
-All skill definitions live under `skills/`. These skills are available on [skill.sh](https://skill.sh). Each section below includes the install command for that skill.
+All skill definitions live under `skills/`. These skills are available on [skills.sh](https://skills.sh). Each section below includes the install command for that skill.
 
 ### visionOS Development
 


### PR DESCRIPTION
Fixes #3

## Summary
- Update the README link text and URL from skill.sh to skills.sh.

## Testing
- Verified README.MD contains the updated skills.sh link.
- Checked https://skills.sh responds and redirects successfully.